### PR TITLE
fix(ui): visible inline and bash code text in light theme

### DIFF
--- a/apps/web/src/styles/mdx.css
+++ b/apps/web/src/styles/mdx.css
@@ -7,6 +7,15 @@ pre [data-line] {
   padding: 0 0.5rem;
 }
 
+.light p > code,
+.light li > code {
+  @apply bg-gray-100;
+}
+
+.light pre > code {
+  @apply text-gray-50;
+}
+
 .mdx > .steps:first-child > h3:first-child {
   @apply mt-0;
 }


### PR DESCRIPTION
### What I changed
1. Changed background color of inline code blocks to Tailwind `gray-100`.
2. Changed CLI/bash text color to Tailwind `neutral-50`.

### Why
- Improves readability in light theme.

#### Fixes #3 

### Screenshots
#### Before ❌
<img width="930" height="269" alt="Screenshot 2025-08-31 174445" src="https://github.com/user-attachments/assets/7e16ea30-36a5-4501-a434-d601c1711abf" />
<img width="921" height="318" alt="image" src="https://github.com/user-attachments/assets/42d75c5b-aa87-4d3a-81bf-d4c7ed081c94" />

#### After ✅
<img width="934" height="242" alt="image" src="https://github.com/user-attachments/assets/4f9a560b-a48a-4174-b6ac-73a13c2b69a6" />
<img width="928" height="334" alt="image" src="https://github.com/user-attachments/assets/c537a7bf-bee1-4713-937b-36a2ccd36fd2" />
